### PR TITLE
Add Consumer and Delivery documentation

### DIFF
--- a/src/consumer.rs
+++ b/src/consumer.rs
@@ -37,6 +37,45 @@ impl<
     }
 }
 
+/// Continuously consumes message from a Queue
+///
+/// A consumer represents the [basic.consume](https://www.rabbitmq.com/amqp-0-9-1-quickref.html#basic.consume) AMQP command.
+/// It continuously receives messages from the queue, as opposed to the
+/// [basic.get](https://www.rabbitmq.com/amqp-0-9-1-quickref.html#basic.get) command, which
+/// retrieves only a single message.
+///
+/// A consumer is obtained by calling [`Channel::basic_consume`] with the queue name.
+/// New messages from this consumer can be accessed by obtaining the iterator from the consumer.
+/// This iterator returns new messages in the form of a
+/// [`Delivery`] for as long as the consumer is subscribed to the queue.
+///
+/// It is important to acknowledge each message if acknowledgments are not disabled by calling
+/// [`Channel::basic_ack`] with the delivery tag of the message.
+///
+/// ## Example
+/// ```rust,no_run
+/// let consumer = channel
+///     .clone()
+///     .basic_consume(
+///         "hello",
+///         "my_consumer",
+///         BasicConsumeOptions::default(),
+///         FieldTable::default(),
+///     )
+///     .await?;
+///
+/// consumer
+///      .for_each(move |delivery| {
+///         let delivery = delivery.expect("error caught in in consumer");
+///         channel
+///             .basic_ack(delivery.delivery_tag, BasicAckOptions::default())
+///             .map(|_| ())
+///     })
+///     .await
+/// ```
+/// [`Channel::basic_consume`]: ./struct.Channel.html#method.basic_consume
+/// [`Delivery`]: ./message/struct.Delivery.html
+/// [`Channel::basic_ack`]: ../struct.Channel.html#method.basic_ack
 #[derive(Clone)]
 pub struct Consumer {
     inner: Arc<Mutex<ConsumerInner>>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,10 @@
 //!
 //! This project follows the AMQP 0.9.1 specifications, targeting especially RabbitMQ.
 //!
+//! The main access point is the [`Channel`], which contains the individual
+//! AMQP methods. As to the AMQP specification, one TCP [`Connection`] can contain
+//! multiple channels.
+//!
 //! ## Feature switches
 //!
 //! * `native-tls` (*default*): enable amqps support through native-tls
@@ -92,6 +96,8 @@
 //!     })
 //! }
 //! ```
+//! [`Channel`]: ./struct.Channel.html
+//! [`Connection`]: ./struct.Connection.html
 
 pub use amq_protocol::{
     auth,

--- a/src/message.rs
+++ b/src/message.rs
@@ -10,13 +10,40 @@ use crate::{
 /// - Err(error) carries the error and is always followed by Ok(None)
 pub type DeliveryResult = Result<Option<(Channel, Delivery)>>;
 
+
+/// A received AMQP message.
+///
+/// The message has to be acknowledged after processing by calling
+/// [`Channel::basic_ack`], [`Channel::basic_reject`] or [`Channel::basic_nack`] with the delivery tag.
+/// (Multiple acknowledgments are also possible).
+///
+/// It is important to acknowledge on the same channel where the message was received.
+///
+/// [`Channel::basic_ack`]: ../struct.Channel.html#method.basic_ack
+/// [`Channel::basic_reject`]: ../struct.Channel.html#method.basic_reject
+/// [`Channel::basic_nack`]: ../struct.Channel.html#method.basic_nack
 #[derive(Clone, Debug, PartialEq)]
 pub struct Delivery {
+    /// The delivery tag of the message. Use this for
+    /// acknowledging the message.
     pub delivery_tag: LongLongUInt,
+
+    /// The exchange of the message. May be an empty string
+    /// if the default exchange is used.
     pub exchange: ShortString,
+
+    /// The routing key of the message. May be an empty string
+    /// if no routing key is specified.
     pub routing_key: ShortString,
+
+    /// Whether this message was redelivered
     pub redelivered: bool,
+
+    /// Contains the properties and the headers of the
+    /// message.
     pub properties: BasicProperties,
+
+    /// The payload of the message in binary format.
     pub data: Vec<u8>,
 }
 


### PR DESCRIPTION
This adds some documentation to the Consumer and Delivery crates.

There might be some errors because of my understanding of the AMQP protocol.