### PR TITLE
Fix warning

### DIFF
--- a/async-std/examples/pubsub-async-std.rs
+++ b/async-std/examples/pubsub-async-std.rs
@@ -48,7 +48,7 @@ async fn main() -> Result<()> {
                 .await
                 .expect("failed to ack");
         }
-    });
+    })?;
 
     let payload = b"Hello world!";
 


### PR DESCRIPTION
`set_delegate` returns a `Result` which must be used. Adding a `?` fixes the warning.