### PR TITLE
Change basic_publish payload from Vec<u8> to &[u8]

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -365,7 +365,7 @@ impl Channel {
     fn send_method_frame_with_body(
         &self,
         method: AMQPClass,
-        payload: Vec<u8>,
+        payload: &[u8],
         properties: BasicProperties,
         publisher_confirms_result: Option<PublisherConfirm>,
     ) -> Result<PromiseChain<PublisherConfirm>> {
@@ -385,7 +385,6 @@ impl Channel {
         // a content body frame 8 bytes of overhead
         frames.extend(
             payload
-                .as_slice()
                 .chunks(frame_max as usize - 8)
                 .map(|chunk| AMQPFrame::Body(self.id, chunk.into())),
         );

--- a/templates/lapin.json
+++ b/templates/lapin.json
@@ -497,7 +497,7 @@
         "extra_args": [
           {
             "name": "payload",
-            "type": "Vec<u8>"
+            "type": "&[u8]"
           },
           {
             "name": "properties",


### PR DESCRIPTION
It looks like basic_publish could accept a payload of `&[u8]` instead of `Vec<u8>`. I made this change, ran regen-code.sh and cargo check and it compiled fine.

Incomplete PR, I didn't update the examples or test against a real server and whatnot. I also didn't commit generated.rs since the diff is a thousand lines long, I probably have the wrong version of rustfmt.

This is a breaking change obviously. But I see 2.0 is on the way, so maybe this is good timing?