### PR TITLE
Revert Frames::push_frames() to 1.8 non-async version, avoids sequencing issue

### DIFF
--- a/src/frames.rs
+++ b/src/frames.rs
@@ -1,4 +1,4 @@
-use crate::{channel::Reply, types::ChannelId, Error, Promise, PromiseResolver, Result};
+use crate::{channel::Reply, types::ChannelId, Error, Promise, PromiseResolver};
 use amq_protocol::{
     frame::AMQPFrame,
     protocol::{basic::AMQPMethod, AMQPClass},
@@ -41,9 +41,8 @@ impl Frames {
             .push(channel_id, frame, resolver, expected_reply);
     }
 
-    pub(crate) async fn push_frames(&self, frames: Vec<AMQPFrame>) -> Result<()> {
-        let promise = self.inner.lock().push_frames(frames);
-        promise.await
+    pub(crate) fn push_frames(&self, frames: Vec<AMQPFrame>) -> Promise<()> {
+        self.inner.lock().push_frames(frames)
     }
 
     pub(crate) fn retry(&self, frame: (AMQPFrame, Option<PromiseResolver<()>>)) {


### PR DESCRIPTION
It's not clear why `Frames::push_frames()` was made `async`, but the net effect is an infrequent but crippling race condition.

As `async` functions do not execute until `await` is called, the result is that this operation may not actually get executed prior to the `wake()` call, meaning things can slip out of order. The `wake()` is triggered before there is data to send, and then this waits for data that won't be sent because the `IoLoop::run()` operation is already in a wait state, as there is nothing to do.

This is the condition the function was in the 1.8 codebase, and it does not have the issue.

A [demonstrator program](https://github.com/postageapp/lapin-kubes/tree/v2-patched) compiled against this branch easily publishes millions of messages without any delays whatsoever. The unpatched version drags along for minutes on end, stalling frequently.

This addresses issue #348.